### PR TITLE
Changed "forward" to "foreword" in filename, config, and title

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -26,7 +26,7 @@ module.exports = {
           collapsable: false,
           sidebarDepth: 1,
           children: [
-            '/book/00__introduction/00__forward.md',
+            '/book/00__introduction/00__foreword.md',
             '/book/00__introduction/01__motivation.md',
             '/book/00__introduction/02__content.md',
           ]

--- a/src/book/00__introduction/00__foreword.md
+++ b/src/book/00__introduction/00__foreword.md
@@ -1,5 +1,5 @@
 ---
-title: "Forward"
+title: "Foreword"
 ---
 
 # {{ $frontmatter.title }}

--- a/src/index.md
+++ b/src/index.md
@@ -2,5 +2,5 @@
 home: true
 tagline: 
 actionText: reee i want 2 read book now →
-actionLink: /book/00__introduction/00__forward.md
+actionLink: /book/00__introduction/00__foreword.md
 ---


### PR DESCRIPTION
I think "Forward" should be "Foreword" in the title of `book/00__introduction/00__forward.md`.

- Renamed `00__forward.md` to `00__foreword.md`.
- Incorporated same change in `config.js` and `index.md`. 
- Tested with `npm run build` and `npm run dev`